### PR TITLE
XSH library: Fix function name typo

### DIFF
--- a/ns/xsh/lib/text/semver.xsh
+++ b/ns/xsh/lib/text/semver.xsh
@@ -2,7 +2,7 @@
 <!-- Copyright © 2011-2018 by Renaud Guillard (dev@nore.fr) -->
 <!-- Distributed under the terms of the MIT License, see LICENSE -->
 <sh:functions xmlns:sh="http://xsd.nore.fr/xsh">
-	<sh:function name="ns_semver_mumber_to_string">
+	<sh:function name="ns_semver_number_to_string">
 		<sh:parameter name="_ns_semver_input" />
 		<sh:body>
 			<sh:local name="_ns_semver_major" type="numeric">0</sh:local>

--- a/unittests/xsh/semver.xsh
+++ b/unittests/xsh/semver.xsh
@@ -3,13 +3,13 @@
 <sh:functions xmlns:sh="http://xsd.nore.fr/xsh" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<xi:include href="../../ns/xsh/lib/text/semver.xsh" xpointer="xmlns(xsh=http://xsd.nore.fr/xsh)xpointer(//xsh:function)" />
 
-	<sh:function name="ns_testsuite_ns_semver_mumber_to_string">
+	<sh:function name="ns_testsuite_ns_semver_number_to_string">
 		<sh:body>
 			<sh:local name="result" type="numeric">0</sh:local>
 		<![CDATA[
-[ "$(ns_semver_mumber_to_string 1)" = "0.0.1" ] || result="$(expr ${result} + 1)"
-[ "$(ns_semver_mumber_to_string 20301)" = "2.3.1" ] || result="$(expr ${result} + 1)"
-[ "$(ns_semver_mumber_to_string abc)" = "" ] || result="$(expr ${result} + 1)"
+[ "$(ns_semver_number_to_string 1)" = "0.0.1" ] || result="$(expr ${result} + 1)"
+[ "$(ns_semver_number_to_string 20301)" = "2.3.1" ] || result="$(expr ${result} + 1)"
+[ "$(ns_semver_number_to_string abc)" = "" ] || result="$(expr ${result} + 1)"
 return ${result}
 ]]></sh:body>
 	</sh:function>


### PR DESCRIPTION
ns_semver_mumber_to_string -> ns_semver_number_to_string